### PR TITLE
Add WebSocketPending endpoint, compatibility with servant-0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 1.1.0
+
+  * Compatibility with servant-0.12.
+  * Added instance for WebSocketPending.
+
 # Version 1.0.0
 
   * Initial release of `servant-websockets`.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 This small library provides two servant endpoints for implementing
 websockets and is based on `websockets` and `wai-websockets`.
 
-This library provides two `servant` endpoints: `WebSocket` and
-`WebSocketConduit`. The former is a low-level interface for directly
+This library provides three `servant` endpoints: `WebSocket`, `WebSocketPending` and
+`WebSocketConduit`. `WebSocket` is is a low-level interface for directly
 interacting with a `Connection` (see the
 [websockets](https://hackage.haskell.org/package/websockets) library
-for more information). The latter provides a
+for more information). `WebSocketPending` allows using the `rejectRequest`
+with various return codes for greater control. `WebSocketConduit`  provides a
 [conduit](https://hackage.haskell.org/package/conduit) based endpoint
 for JSON serializable input and output.
 

--- a/servant-websockets.cabal
+++ b/servant-websockets.cabal
@@ -1,5 +1,5 @@
 name:                servant-websockets
-version:             1.0.0
+version:             1.1.0
 homepage:            https://github.com/moesenle/servant-websockets#readme
 synopsis:            Small library providing WebSocket endpoints for servant.
 description:         Small library providing WebSocket endpoints for servant.

--- a/src/Servant/API/WebSocket.hs
+++ b/src/Servant/API/WebSocket.hs
@@ -9,7 +9,7 @@ import Control.Monad.IO.Class                     (liftIO)
 import Control.Monad.Trans.Resource               (runResourceT)
 import Data.Proxy                                 (Proxy (..))
 import Network.Wai.Handler.WebSockets             (websocketsOr)
-import Network.WebSockets                         (Connection, acceptRequest, defaultConnectionOptions)
+import Network.WebSockets                         (Connection, PendingConnection, acceptRequest, defaultConnectionOptions)
 import Servant.Server                             (HasServer (..), ServantErr (..), ServerT, runHandler)
 import Servant.Server.Internal.Router             (leafRouter)
 import Servant.Server.Internal.RoutingApplication (RouteResult (..), runDelayed)
@@ -44,6 +44,45 @@ instance HasServer WebSocket ctx where
     go _ respond (FailFatal e) = respond $ FailFatal e
 
     runApp a = acceptRequest >=> \c -> void (runHandler $ a c)
+
+    backupApp respond _ _ = respond $ Fail ServantErr { errHTTPCode = 426
+                                                      , errReasonPhrase = "Upgrade Required"
+                                                      , errBody = mempty
+                                                      , errHeaders = mempty
+                                                      }
+
+
+-- | Endpoint for defining a route to provide a web socket. The
+-- handler function gets a 'PendingConnection'. It can either
+-- 'rejectConnection' or 'acceptRequest'. This function is provided
+-- for greater flexibility to reject connections.
+--
+-- Example:
+--
+-- > type WebSocketApi = "stream" :> WebSocket
+-- >
+-- > server :: Server WebSocketApi
+-- > server = streamData
+-- >  where
+-- >   streamData :: MonadIO m => Connection -> m ()
+-- >   streamData c = liftIO . forM_ [1..] $ \i -> do
+-- >     forkPingThread c 10
+-- >     sendTextData c (pack $ show (i :: Int)) >> threadDelay 1000000
+data WebSocketPending
+
+instance HasServer WebSocketPending ctx where
+
+  type ServerT WebSocketPending m = PendingConnection -> m ()
+
+  route Proxy _ app = leafRouter $ \env request respond -> runResourceT $
+    runDelayed app env request >>= liftIO . go request respond
+   where
+    go request respond (Route app') =
+      websocketsOr defaultConnectionOptions (runApp app') (backupApp respond) request (respond . Route)
+    go _ respond (Fail e) = respond $ Fail e
+    go _ respond (FailFatal e) = respond $ FailFatal e
+
+    runApp a c = void (runHandler $ a c)
 
     backupApp respond _ _ = respond $ Fail ServantErr { errHTTPCode = 426
                                                       , errReasonPhrase = "Upgrade Required"

--- a/src/Servant/API/WebSocket.hs
+++ b/src/Servant/API/WebSocket.hs
@@ -27,9 +27,10 @@ import Servant.Server.Internal.RoutingApplication (RouteResult (..), runDelayed)
 -- > server = streamData
 -- >  where
 -- >   streamData :: MonadIO m => Connection -> m ()
--- >   streamData c = liftIO . forM_ [1..] $ \i -> do
--- >     forkPingThread c 10
--- >     sendTextData c (pack $ show (i :: Int)) >> threadDelay 1000000
+-- >   streamData c = do
+-- >     liftIO $ forkPingThread c 10
+-- >     liftIO . forM_ [1..] $ \i -> do
+-- >        sendTextData c (pack $ show (i :: Int)) >> threadDelay 1000000
 data WebSocket
 
 instance HasServer WebSocket ctx where
@@ -59,20 +60,22 @@ instance HasServer WebSocket ctx where
 
 -- | Endpoint for defining a route to provide a web socket. The
 -- handler function gets a 'PendingConnection'. It can either
--- 'rejectConnection' or 'acceptRequest'. This function is provided
+-- 'rejectRequest' or 'acceptRequest'. This function is provided
 -- for greater flexibility to reject connections.
 --
 -- Example:
 --
--- > type WebSocketApi = "stream" :> WebSocket
+-- > type WebSocketApi = "stream" :> WebSocketPending
 -- >
 -- > server :: Server WebSocketApi
 -- > server = streamData
 -- >  where
--- >   streamData :: MonadIO m => Connection -> m ()
--- >   streamData c = liftIO . forM_ [1..] $ \i -> do
--- >     forkPingThread c 10
--- >     sendTextData c (pack $ show (i :: Int)) >> threadDelay 1000000
+-- >   streamData :: MonadIO m => PendingConnection -> m ()
+-- >   streamData pc = do
+-- >      c <- acceptRequest pc
+-- >      liftIO $ forkPingThread c 10
+-- >      liftIO . forM_ [1..] $ \i ->
+-- >        sendTextData c (pack $ show (i :: Int)) >> threadDelay 1000000
 data WebSocketPending
 
 instance HasServer WebSocketPending ctx where

--- a/src/Servant/API/WebSocket.hs
+++ b/src/Servant/API/WebSocket.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies          #-}
@@ -34,6 +35,10 @@ data WebSocket
 instance HasServer WebSocket ctx where
 
   type ServerT WebSocket m = Connection -> m ()
+
+  #if MIN_VERSION_servant_server(0,12,0)
+  hoistServerWithContext _ _ nat svr = nat . svr
+  #endif
 
   route Proxy _ app = leafRouter $ \env request respond -> runResourceT $
     runDelayed app env request >>= liftIO . go request respond
@@ -73,6 +78,10 @@ data WebSocketPending
 instance HasServer WebSocketPending ctx where
 
   type ServerT WebSocketPending m = PendingConnection -> m ()
+
+  #if MIN_VERSION_servant_server(0,12,0)
+  hoistServerWithContext _ _ nat svr = nat . svr
+  #endif
 
   route Proxy _ app = leafRouter $ \env request respond -> runResourceT $
     runDelayed app env request >>= liftIO . go request respond

--- a/src/Servant/API/WebSocketConduit.hs
+++ b/src/Servant/API/WebSocketConduit.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -56,6 +57,10 @@ data WebSocketConduit i o
 instance (FromJSON i, ToJSON o) => HasServer (WebSocketConduit i o) ctx where
 
   type ServerT (WebSocketConduit i o) m = Conduit i (ResourceT IO) o
+
+  #if MIN_VERSION_servant_server(0,12,0)
+  hoistServerWithContext _ _ _ svr = svr
+  #endif
 
   route Proxy _ app = leafRouter $ \env request respond -> runResourceT $
     runDelayed app env request >>= liftIO . go request respond


### PR DESCRIPTION
I needed a little more control over accepting connections so I added `WebSocketPending` endpoint. I have also added compatibility with servant-0.12, it has more methods in the `HasServer` instance.