### PR TITLE
Use Text for UTF-8 instead of aeson Value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work
+dist-newstyle

--- a/examples/Echo.hs
+++ b/examples/Echo.hs
@@ -19,7 +19,7 @@ import Servant                  ((:<|>) (..), (:>), Proxy (..), Server, serve)
 import qualified Data.Conduit.List as CL
 
 
-type API = "echo" :> WebSocketConduit Value Value
+type API = "echo" :> WebSocketConduit Text Text
            :<|> "hello" :> WebSocketSource Text
 
 startApp :: IO ()
@@ -36,7 +36,7 @@ api = Proxy
 server :: Server API
 server = echo :<|> hello
 
-echo :: Monad m => ConduitT Value Value m ()
+echo :: Monad m => ConduitT Text Text m ()
 echo = CL.map id
 
 hello :: MonadIO m => ConduitT () Text m ()

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.0
+resolver: lts-19.33
 packages:
 - .
 extra-deps: []


### PR DESCRIPTION
Not sure if this library is still maintained...

This MR replaces the `ToJson, FromJson` requirement for the `WebSocketConduit` with [WebSocketsData](https://hackage.haskell.org/package/websockets-0.12.7.3/docs/Network-WebSockets.html#t:WebSocketsData) instead. This is a breaking change. Old code probably wont compile anymore.

With `WebSocketsData` you use `Text` when transmitting UTF-8 and `ByteString` when transmitting binary.