### PR TITLE
Add support for more of the WebSocket API

### DIFF
--- a/examples/Stream.hs
+++ b/examples/Stream.hs
@@ -12,8 +12,8 @@ import Data.Foldable            (forM_)
 import Data.Text                (pack)
 import Network.Wai              (Application)
 import Network.Wai.Handler.Warp (run)
-import Network.WebSockets       (Connection, forkPingThread, sendTextData)
-import Servant                  ((:>), Proxy (..), Server, serve)
+import Network.WebSockets       (Connection, forkPingThread, sendTextData, withPingThread)
+import Servant                  (Proxy (..), Server, serve, (:>))
 
 type WebSocketApi = "stream" :> WebSocket
 
@@ -33,8 +33,7 @@ server = streamData
  where
    streamData :: MonadIO m => Connection -> m ()
    streamData c = liftIO . forM_ [1..] $ \i -> do
-     forkPingThread c 10
-     sendTextData c (pack $ show (i :: Int)) >> threadDelay 1000000
+     withPingThread c 10 (pure ()) $ sendTextData c (pack $ show (i :: Int)) >> threadDelay 1000000
 
 main :: IO ()
 main = startApp

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,345 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "horizon-core": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "lint-utils": "lint-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1699788548,
+        "narHash": "sha256-9XTNSqYxT3HzVIglLW4UprhVMjyDsZzQY8s0qZDS+nw=",
+        "ref": "lts/ghc-9.4.x",
+        "rev": "3d5cb59b2e770f825f3927f26c279f69a6e2c490",
+        "revCount": 1184,
+        "type": "git",
+        "url": "https://gitlab.horizon-haskell.net/package-sets/horizon-core"
+      },
+      "original": {
+        "ref": "lts/ghc-9.4.x",
+        "type": "git",
+        "url": "https://gitlab.horizon-haskell.net/package-sets/horizon-core"
+      }
+    },
+    "horizon-platform": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "horizon-core": "horizon-core",
+        "lint-utils": "lint-utils_2",
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1699798357,
+        "narHash": "sha256-nQXFpDYHoy3uh0aGkgsXSOlIOGYbky5dRPNmG8k6FnM=",
+        "ref": "refs/heads/master",
+        "rev": "f611fc1c4d45a64fe8f23b2eb0dfe0146505157d",
+        "revCount": 1158,
+        "type": "git",
+        "url": "https://gitlab.horizon-haskell.net/package-sets/horizon-platform"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://gitlab.horizon-haskell.net/package-sets/horizon-platform"
+      }
+    },
+    "lint-utils": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1699441004,
+        "narHash": "sha256-7v7CH8ZiB2RClPtpgDLfQxeR+14KXoFl2qTdXd27sL0=",
+        "ref": "refs/heads/master",
+        "rev": "226003d10c2d192b088f7c3c9ee7ca549c421a9c",
+        "revCount": 52,
+        "type": "git",
+        "url": "https://gitlab.nixica.dev/nix/lint-utils"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://gitlab.nixica.dev/nix/lint-utils"
+      }
+    },
+    "lint-utils_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1699441004,
+        "narHash": "sha256-7v7CH8ZiB2RClPtpgDLfQxeR+14KXoFl2qTdXd27sL0=",
+        "ref": "refs/heads/master",
+        "rev": "226003d10c2d192b088f7c3c9ee7ca549c421a9c",
+        "revCount": 52,
+        "type": "git",
+        "url": "https://gitlab.nixica.dev/nix/lint-utils"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://gitlab.nixica.dev/nix/lint-utils"
+      }
+    },
+    "lint-utils_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701713103,
+        "narHash": "sha256-IstHSRxNrhyYTeIWAaUjmkdtGFXQlgQQdr28le1RwGA=",
+        "ref": "refs/heads/master",
+        "rev": "4dffa421c015db30f3755bfa358b15fc9cf5c6ff",
+        "revCount": 56,
+        "type": "git",
+        "url": "https://gitlab.nixica.dev/nix/lint-utils.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://gitlab.nixica.dev/nix/lint-utils.git"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1644525281,
+        "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "48d63e924a2666baf37f4f14a18f19347fbd54a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1699099776,
+        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1644525281,
+        "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "48d63e924a2666baf37f4f14a18f19347fbd54a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1699601893,
+        "narHash": "sha256-9f008k1k5SmEAO1ldjO5sQf+oWHFkeK5jhS3Ji3vFyk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e06c716ef149f466f25e62a836c30b90476e65e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1703499205,
+        "narHash": "sha256-lF9rK5mSUfIZJgZxC3ge40tp1gmyyOXZ+lRY3P8bfbg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e1fa12d4f6c6fe19ccb59cac54b5b3f25e160870",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "horizon-platform": "horizon-platform",
+        "lint-utils": "lint-utils_3",
+        "nixpkgs": "nixpkgs_5"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,129 @@
+{
+  description = "Servant WebSocket";
+
+  nixConfig = {
+    extra-substituters = "https://horizon.cachix.org";
+    extra-trusted-public-keys = "horizon.cachix.org-1:MeEEDRhRZTgv/FFGCv3479/dmJDfJ82G6kfUDxMSAw0=";
+  };
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    horizon-platform.url = "git+https://gitlab.horizon-haskell.net/package-sets/horizon-platform";
+
+    lint-utils = {
+      url = "git+https://gitlab.nixica.dev/nix/lint-utils.git";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs =
+    inputs@
+    { self
+    , flake-utils
+    , lint-utils
+    , horizon-platform
+    , nixpkgs
+    , ...
+    }: with builtins; let
+      inherit (inputs.nixpkgs) lib;
+      onlyHaskell = fs2source
+        (fs.union
+          (onlyExts-fs [ "cabal" "hs" "project" ] ./.)
+          ./LICENSE # horizon requires this file to build
+        );
+      fs = lib.fileset;
+      fs2source = fs': path: fs.toSource { root = path; fileset = fs'; };
+      onlyExts-fs = exts: fs.fileFilter (f: foldl' lib.or false (map f.hasExt exts));
+      onlyExts = exts: path: fs2source (onlyExts-fs exts path) path;
+
+    in
+    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ]
+      (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        hlib = pkgs.haskell.lib;
+
+        legacyPackages =
+          horizon-platform.legacyPackages.${system}.extend
+            self.haskell-overlay.${system}.default;
+      in
+      rec {
+        haskell-overlay.default = final: prev: {
+          servant-websocket = final.callCabal2nix "servant-websocket" (onlyHaskell ./.) { };
+        };
+        packages.default = hlib.setBuildTarget legacyPackages.servant-websocket "lib:servant-websocket";
+        devShells.default = legacyPackages.servant-websocket.env.overrideAttrs (attrs: {
+          buildInputs = attrs.buildInputs ++ (with pkgs; [
+            cabal-install
+            haskellPackages.cabal-fmt
+            legacyPackages.ghcid
+            legacyPackages.hlint
+            legacyPackages.haskell-language-server
+            nixpkgs-fmt
+            stylish-haskell
+          ]);
+
+          shellHook =
+            let
+              instructions = ''
+                ${write-descriptions general-functions}
+              '';
+
+              general-functions = {
+                format = {
+                  description = "format code";
+                  body = ''
+                    nix fmt
+                    stylish-haskell -ir .
+                    cabal-fmt -i *.cabal
+                  '';
+                };
+
+                shelp = {
+                  description = "show this message";
+                  body = "echo ${lib.escapeShellArg instructions}";
+                };
+              };
+
+
+              write-set = set: f: concatStringsSep "\n" (lib.mapAttrsToList f set);
+
+              write-descriptions = set: ''
+                ${write-set set (n: v: "  ${n}\t${v.description}")}'';
+            in
+            ''
+              ${write-set (general-functions)
+                  (n: v: ''
+                     ${n}() {
+                       ${v.body}
+                     }
+                   '')
+              }
+
+              shelp
+            '';
+        });
+
+        checks = let lu = lint-utils.linters.${system}; in {
+          cabal-formatting = lu.cabal-fmt { src = onlyExts [ "cabal" ] ./.; };
+          haskell-warnings = lu.werror { pkg = legacyPackages.servant-websocket; };
+          haskell-formatting = lu.stylish-haskell {
+            src = fs2source
+              (fs.union (onlyExts-fs [ "hs" ] ./.) ./.stylish-haskell.yaml)
+              ./.;
+          };
+          haskell-linting = lu.hlint {
+            src = fs2source
+              (fs.union (onlyExts-fs [ "hs" ] ./.) ./.hlint.yaml)
+              ./.;
+          };
+
+          nix-formatting = lu.nixpkgs-fmt { src = onlyExts [ "nix" ] ./.; };
+
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}

--- a/servant-websockets.cabal
+++ b/servant-websockets.cabal
@@ -1,5 +1,5 @@
 name:                servant-websockets
-version:             1.2.0
+version:             2.1.0
 homepage:            https://github.com/moesenle/servant-websockets#readme
 synopsis:            Small library providing WebSocket endpoints for servant.
 description:         Small library providing WebSocket endpoints for servant.

--- a/src/Servant/API/WebSocketConduit.hs
+++ b/src/Servant/API/WebSocketConduit.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes      #-}
 {-# LANGUAGE CPP                      #-}
 {-# LANGUAGE DataKinds                #-}
+{-# LANGUAGE DeriveGeneric            #-}
 {-# LANGUAGE FlexibleContexts         #-}
 {-# LANGUAGE FlexibleInstances        #-}
 {-# LANGUAGE MultiParamTypeClasses    #-}
@@ -27,6 +28,8 @@ import           Data.Kind                           (Constraint, Type)
 import           Data.Proxy                          (Proxy (..))
 import           Data.String                         (IsString (..))
 import           Data.Text                           (Text)
+import           Data.Typeable                       (Typeable)
+import           GHC.Generics                        (Generic)
 import           GHC.TypeLits                        (Symbol, symbolVal)
 import           Network.Wai.Handler.WebSockets      (websocketsOr)
 import           Network.WebSockets                  (AcceptRequest (acceptHeaders), Connection, ConnectionException,
@@ -66,6 +69,7 @@ import           Servant.Server.Internal.RouteResult (RouteResult (..))
 -- example only echos valid JSON data.
 type MessageType :: Type
 data MessageType = JSONMessage | BinaryMessage
+  deriving (Eq, Ord, Enum, Bounded, Generic, Typeable)
 
 type role WebSocketConduitRaw nominal nominal nominal nominal
 type WebSocketConduitRaw :: Maybe Symbol -> MessageType -> Type -> Type -> Type


### PR DESCRIPTION
This PR adds

- `flake.nix` for DX
- Adds extra arguments to the `WebSocketConduit` combinator to allow for Sec protocol header, and binary streaming
- If a Sec protocol is present, it echos back what was sent, as per protocol 